### PR TITLE
cloudvisor/ec2_wrapper.py: only delete dangling security groups older…

### DIFF
--- a/resource_managers/cloudvisor/__main__.py
+++ b/resource_managers/cloudvisor/__main__.py
@@ -19,7 +19,8 @@ import logging
 def _configure_logging(log_level):
     logging.getLogger('boto3').setLevel(logging.WARNING)
     logging.getLogger('botocore').setLevel(logging.WARNING)
-    anylogging.configure_logging(root_level=log_level, console_level=log_level)
+    anylogging.configure_logging(root_level=log_level, console_level=log_level, file_level=log_level,
+                                 filename='/var/log/cloudvisor.log')
 
 
 def resolve_ip():

--- a/resource_managers/cloudvisor/ec2_wrapper.py
+++ b/resource_managers/cloudvisor/ec2_wrapper.py
@@ -1,6 +1,6 @@
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import logging
 
@@ -118,7 +118,8 @@ class EC2Wrapper(object):
     def _create_security_group(self, vm):
         allocating_ip = vm.client_external_ip
         sg_name = f"automation_allocation_{vm.allocation_id}"
-        tags = EC2Wrapper._default_tags(vm) + [{'Key': 'Name', 'Value': sg_name}]
+        tags = EC2Wrapper._default_tags(vm) + [{'Key': 'Name', 'Value': sg_name}] + \
+               [{'Key': 'creation', 'Value': datetime.now()}]
 
         security_group = self.boto_ec2.create_security_group(Description=vm.allocation_id,
                                                              GroupName=vm.allocation_id,
@@ -265,6 +266,8 @@ class EC2Wrapper(object):
 
     def delete_dangling_security_groups(self):
         for security_group in self._automation_security_groups():
+            if (datetime.now() - self._tags_dict(security_group).get('creation', datetime.min)) < timedelta(minutes=5):
+                continue
             security_group.reload()
             if not security_group.get_available_subresources():
                 try:


### PR DESCRIPTION
… than 5 minutes

Deleting vms takes a long time, so when requesting to delete a VM we
dont wait for it to finish, rather we send the delete command and return
success.
Security groups cant be deleting if they have resources which rely on
them.
These 2 facts make it necessary to run a secondary thread which wakes up
every X time and deletes dangling security groups, whose vms were
successfully deleted.
The problem is that the security group is obv created before the VM, so
there can be a rare situation where a security group is created, and
then before the vm is created the secondary thread deletes the security
group, because it thinks no vms rely on it (this is bc the vm is still
in the process of being created). This causes the vm creation to fail
(and therefore the allocation to fail), even though it shouldn't.

The easiest solution (for now) is to ignore security groups which were
created less then 5 mins ago when cleaning SGs, but creation time isn't
saved in the SG object. So to work around that I added a creation tag to
the SG, so that we can keep track of when they were created and delete
accordingly.