### PR TITLE
ec2_manager | changed gpu instance types

### DIFF
--- a/resource_managers/cloudvisor/ec2_manager.py
+++ b/resource_managers/cloudvisor/ec2_manager.py
@@ -6,10 +6,9 @@ import logging
 from cloudvisor.cloud_vm import VM
 from botocore.exceptions import ClientError
 
-INSTANCE_TYPES_BY_GPU_COUNT = {'1': ['g3.4xlarge', 'g4dn.2xlarge', 'g4dn.4xlarge'],
-                               '2': ['g3.8xlarge'],
-                               '4': ['g4dn.12xlarge', 'g3.16xlarge'],
-                               '8': ['p2.8xlarge', 'p3.16xlarge' ]}
+INSTANCE_TYPES_BY_GPU_COUNT = {'1': ['g4dn.2xlarge', 'g4dn.4xlarge'],
+                               '4': ['g4dn.12xlarge'],
+                               '8': ['p3.16xlarge', 'g4dn.metal']}
 
 
 class EC2Manager(object):


### PR DESCRIPTION
Due to the pipeng trt7 change, there are unsupported machine types that we need to remove from the list
removed g3 and g2 machine types 
removed the option to use the "2 GPUs" machine as we don't have a supported machine type for this